### PR TITLE
Add documentation for Bergama land use GeoPackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # QgislandUseSurveyDB
+
 Proje, coğrafi bilgi sistemleri (CBS) ortamında arazi kullanım ve örtüsü tiplerinin hızlı ve tutarlı bir şekilde envanterinin çıkarılması için gerekli olan tablo şemalarını, ilişki matrislerini ve veri sözlüğünü sunar. QGIS masaüstü ve QField/Input gibi mobil uygulamalarla saha verisi toplama sürecini optimize etmeyi amaçlar.
+
+## Depo Hakkında
+
+Bu depo Bergama ilçesine ait arazi kullanım verilerinin yönetimi ve saha anketi süreçlerinin dijitalleştirilmesi için hazırlanmıştır. Temel veri kaynağı **AraziKullanimDB.gpkg** adlı GeoPackage dosyasıdır. GeoPackage; binalar, yollar, çevre düzeni planı, alan grupları, saha çalışma sınırı ve 1/1000 ölçekli ada poligonlarını tek bir dosyada barındırır. Öğrencilerin sahada topladığı güncel ada bilgileri hem çizgisel hem de alansal detaylarıyla kayıt altına alınabilir.
+
+## Özellikler
+
+* **QGIS uyumu:** GeoPackage dosyası doğrudan QGIS'e eklenerek katmanlara erişim sağlanır.
+* **QField / Input entegrasyonu:** Arazi anket formları ve alan doğrulama süreçleri için mobil cihazlarda kullanılabilecek optimize edilmiş bir şema sunar.
+* **Çok katmanlı veri yapısı:** Bina, yol, çevre düzeni ve ada sınırı gibi katmanlar tek dosyada yönetilir.
+* **Standartlaştırılmış öznitelik şeması:** Arazi kullanım tipleri, plan kararları ve saha notları için ortak alan adları kullanılır.
+
+## Başlangıç
+
+1. `AraziKullanimDB.gpkg` dosyasını depodaki `data/` klasörüne kopyalayın veya [sistem tarafından sağlanan konuma](docs/data_dictionary.md#geopackage-dosyasi) yerleştirin.
+2. QGIS (3.22 veya üzeri) uygulamasını açın ve **Veri Kaynağı Yöneticisi** üzerinden GeoPackage dosyasını projeye ekleyin.
+3. Katmanları inceleyin ve `docs/data_dictionary.md` dosyasındaki tabloyu referans alarak öznitelik alanlarını gözden geçirin.
+4. QField Sync eklentisi ile sahaya çıkmadan önce projeyi mobil cihazlara aktarın.
+
+## Tavsiye Edilen Proje Yapısı
+
+```
+QgislandUseSurveyDB/
+├── data/
+│   └── AraziKullanimDB.gpkg
+├── docs/
+│   └── data_dictionary.md
+├── qgis/
+│   └── Bergama_Arastirma.qgz (opsiyonel proje dosyası)
+└── README.md
+```
+
+> **Not:** GeoPackage dosyası büyük boyutlu olduğundan sürüm kontrolüne dahil edilmez. Dosyayı depoya eklemek yerine `data/` klasöründe yerel olarak tutmanız önerilir.
+
+## QField / Input ile Saha Çalışması
+
+1. QGIS projesini hazırladıktan sonra **QFieldSync** eklentisini yükleyin.
+2. Projeyi hedef klasöre senkronize edin ve `Input`/`QField` uygulamasında açın.
+3. `AlanCalismaSiniri` katmanını "yalnızca oku" moduna alın, diğer katmanlara düzenleme yetkisi verin.
+4. Saha sırasında anket formunu doldurmak için **AlanGruplari** katmanındaki form bileşenlerini kullanın.
+5. Çalışma tamamlandıktan sonra cihazı QGIS'e bağlayın ve değişiklikleri birleştirin.
+
+## Veri Kalite Kontrolleri
+
+* **Geometri doğrulama:** QGIS'te `Vector > Geometry Tools > Check Validity` aracıyla geçersiz geometrileri kontrol edin.
+* **Alan değerleri:** `AraziTuru`, `PlanKarari` gibi alanlar için kod listelerini kullanın. Kod listeleri `docs/data_dictionary.md` dosyasında yer alır.
+* **Alan çatışmaları:** Ada poligonları ile bina sınırlarının çakışmasını kontrol etmek için `Select by Location` fonksiyonundan yararlanın.
+
+## Katkıda Bulunma
+
+1. Bu depoyu forklayın ve yerel ortamınıza klonlayın.
+2. Yeni bir dal oluşturun: `git checkout -b ozellik/ogrenci-formu`.
+3. Yaptığınız değişiklikleri test edin ve `docs/data_dictionary.md` dosyasındaki yönergeleri güncel tutun.
+4. Pull request açarak değişikliklerin gözden geçirilmesini talep edin.
+
+## Lisans
+
+Bu proje [MIT Lisansı](LICENSE) kapsamında lisanslanmıştır.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,10 @@
+# GeoPackage ve diğer büyük veri dosyalarını sürüm kontrolü dışında tut
+*.gpkg
+*.gpkg-shm
+*.gpkg-wal
+*.sqlite
+*.tif
+*.zip
+
+# Saha çalışmalarında oluşan medya dosyaları
+media/

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -1,0 +1,112 @@
+# Arazi Kullanım GeoPackage Veri Sözlüğü
+
+Bu doküman, `AraziKullanimDB.gpkg` GeoPackage dosyasında bulunan ana katmanları, öznitelik alanlarını ve alanların amaçlanan kullanımını özetler. Dosya, Bergama çalışma alanında yapılan arazi kullanım envanterinin dijital kaydıdır ve hem ofis hem de saha ekiplerinin ortak bir veri modeli üzerinden çalışmasını sağlar.
+
+## GeoPackage Dosyası
+
+| Özellik | Değer |
+| --- | --- |
+| Dosya adı | `AraziKullanimDB.gpkg` |
+| Koordinat Referans Sistemi | EPSG:5254 (ITRF96 / TM30 3 Derece) önerilir |
+| Varsayılan Ölçek | 1/1000 |
+| Temel Kullanım | QGIS masaüstü ve QField/Input saha uygulamaları |
+
+## Katmanlar
+
+### 1. `Bergama_Binalar`
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `bina_id` | Tamsayı | Her bina için benzersiz kimlik. |
+| `ada_no` | Metin | 1/1000 ölçekli ada numarası. |
+| `kullanim_turu` | Metin | Bina kullanım fonksiyonu (konut, ticaret, karma vb.). |
+| `kat_sayisi` | Tamsayı | Bina kat adedi. |
+| `yapi_durumu` | Metin | Yapının durumu (mevcut, yıkık, inşaat vb.). |
+| `foto_url` | Metin | Saha fotoğrafı bağlantısı veya dosya adı. |
+| `notlar` | Metin | Serbest metin notları. |
+
+### 2. `Bergama_Yollari`
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `yol_id` | Tamsayı | Yol segmenti kimliği. |
+| `ada_no` | Metin | Yolun geçtiği ada numarası. |
+| `kaplama` | Metin | Kaplama türü (asfalt, parke, stabilize). |
+| `genislik_m` | Ondalık | Tahmini yol genişliği (metre). |
+| `ulasim_turu` | Metin | Araç, yaya, bisiklet vb. |
+| `notlar` | Metin | Ek açıklamalar. |
+
+### 3. `CevreDuzeniPlani`
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `plan_id` | Tamsayı | Plan dilimi kimliği. |
+| `plan_karari` | Metin | Çevre düzeni planındaki arazi kullanım kararı. |
+| `alt_olcek` | Metin | İlgili alt ölçek (örn. 1/25.000). |
+| `onay_tarihi` | Tarih | Plan kararının onay tarihi. |
+
+### 4. `AlanGruplari`
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `grup_id` | Tamsayı | Anket formu kayıt kimliği. |
+| `alan_turu` | Metin | Arazi kullanım türü (tarım, sanayi, yeşil alan vb.). |
+| `grup_kodu` | Metin | Alan grubu için kod listesi değeri. |
+| `durum` | Metin | Aktif, planlanan veya öneri gibi durum bilgisi. |
+| `guncelleyen` | Metin | Son düzenlemeyi yapan kişi veya ekip. |
+| `guncelleme_tarihi` | Tarih | Son düzenleme tarihi. |
+| `anket_notu` | Metin | Saha anketinden alınan özet not. |
+
+### 5. `AlanCalismaSiniri`
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `sinir_id` | Tamsayı | Çalışma sınırı kimliği. |
+| `proje_adi` | Metin | Proje veya saha kampanyasının adı. |
+| `aciklama` | Metin | Sınırın tanımı ve kapsamı. |
+
+### 6. `Ada1000`
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `ada_id` | Tamsayı | 1/1000 ölçekli ada kimliği. |
+| `ada_no` | Metin | İlgili resmi ada numarası. |
+| `ilce` | Metin | İlçe adı (Bergama). |
+| `mahalle` | Metin | Mahalle adı. |
+| `yuzolcumu` | Ondalık | Ada yüzölçümü (metrekare). |
+
+## Kod Listeleri
+
+### `AlanGruplari.alan_turu`
+
+| Kod | Açıklama |
+| --- | --- |
+| `TAR` | Tarımsal üretim alanı |
+| `SAN` | Sanayi / Depolama |
+| `YES` | Yeşil alan / Park |
+| `KON` | Konut |
+| `TIC` | Ticaret |
+| `KAM` | Kamu hizmeti |
+
+### `Bergama_Binalar.kullanim_turu`
+
+| Kod | Açıklama |
+| --- | --- |
+| `R` | Konut |
+| `C` | Ticari |
+| `M` | Karma |
+| `I` | Sanayi |
+| `P` | Kamu |
+
+## Veri Yönetimi İpuçları
+
+* `bina_id`, `yol_id`, `grup_id` gibi tamsayı alanları otomatik artan kimlik alanları olarak kullanın ve kopya kayıt oluşturmaktan kaçının.
+* Saha sırasında fotoğraf çekimi yapılıyorsa `foto_url` alanına göreli dosya yolu (örn. `media/2024-bergama/bina_102.jpg`) yazın.
+* Değişiklik geçmişini izlemek için QGIS'te "Alan Ekle" aracını kullanarak `guncelleme_tarihi` alanını otomatik güncelleyen ifadeler tanımlayın.
+
+## Sürüm Kontrolü Tavsiyeleri
+
+* GeoPackage dosyasını Git LFS veya harici bir bulut depolama alanında saklayın.
+* `data/` klasöründe `.gitignore` dosyası oluşturarak büyük boyutlu verilerin yanlışlıkla sürüm kontrolüne eklenmesini engelleyin.
+* Form yapılandırmalarında yapılan değişiklikleri belgelemeniz için bu doküman üzerinde ilgili bölümü güncelleyin.
+


### PR DESCRIPTION
## Summary
- expand the README with usage guidance for the AraziKullanimDB.gpkg GeoPackage and QField workflow
- add a detailed data dictionary covering the Bergama layers and attribute fields
- ignore large GeoPackage and media files in the data directory to keep the repository lightweight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db00f61eac832da81daa9e6f62e3ac