### PR TITLE
Enhance README with QGIS setup workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
 # QgislandUseSurveyDB
+
 Proje, coğrafi bilgi sistemleri (CBS) ortamında arazi kullanım ve örtüsü tiplerinin hızlı ve tutarlı bir şekilde envanterinin çıkarılması için gerekli olan tablo şemalarını, ilişki matrislerini ve veri sözlüğünü sunar. QGIS masaüstü ve QField/Input gibi mobil uygulamalarla saha verisi toplama sürecini optimize etmeyi amaçlar.
+
+## Depo Hakkında
+
+Bu depo Bergama ilçesine ait arazi kullanım verilerinin yönetimi ve saha anketi süreçlerinin dijitalleştirilmesi için hazırlanmıştır. Temel veri kaynağı **AraziKullanimDB.gpkg** adlı GeoPackage dosyasıdır. GeoPackage; binalar, yollar, çevre düzeni planı, alan grupları, saha çalışma sınırı ve çalışma ölçeği 1/5000 olan tematik katmanları içerir. Ada poligonlarının çizimi 1/1000 detayında yapılmış, ancak analiz ve plan kararları 1/5000 ölçeği referans alacak şekilde yapılandırılmıştır. Öğrencilerin sahada topladığı güncel ada bilgileri hem çizgisel hem de alansal detaylarıyla kayıt altına alınabilir. Mobil form kurulumları ve QField/Input uyarlamaları yapılmıştır; dosya yerel ortama taşındığında saha veya ofis düzenlemeleri için hazırdır.
+
+## Neden Bu Depo?
+
+* **QGIS uyumu:** GeoPackage dosyası doğrudan QGIS'e eklenerek katmanlara erişim sağlanır. Tüm katmanlar EPSG:5253 koordinat referans sistemini kullanır.
+* **QField / Input entegrasyonu:** Arazi anket formları ve alan doğrulama süreçleri için mobil cihazlarda kullanılabilecek optimize edilmiş bir şema sunar.
+* **Çok katmanlı veri yapısı:** Bina, yol, çevre düzeni ve ada sınırı gibi katmanlar tek dosyada yönetilir.
+* **Standartlaştırılmış öznitelik şeması:** Arazi kullanım tipleri, plan kararları ve saha notları için ortak alan adları kullanılır.
+* **Ölçek uyumu:** Planlama ve analizler 1/5000 ölçeğine göre organize edilir; ada çizimleri sahada 1/1000 detayında gözden geçirilir.
+
+## Katman Odakları
+
+* **CIZGI (Çizgi Fonksiyonları):** Yol fonksiyonları, genişlik değerleri ve kaplama türleri için değer haritaları içerir. Form görünümünde `is_valid($geometry)` ifadesi ile geçersiz geometriler kırmızı vurgulanır.
+* **ALAN (Arazi Kullanımı):** Alternatif fonksiyon kod listeleri, hâkim yapı türü seçenekleri ve yapı yılı, kat sayısı gibi plan notları sahada girilir. Bu katmanda da `is_valid($geometry)` kontrolü form koşullu biçimlendirmesine bağlıdır.
+
+## Kurulum ve Hazırlık Adımları
+
+Aşağıdaki sıralama, GeoPackage'ı indirip QGIS projesini açtıktan sonra veri üretimine vakit kaybetmeden başlayabilmeniz için tasarlandı:
+
+1. **Dosyayı çöz ve arşivle:** Depoda sağlanan `AraziKullanimDB.zip` (veya kurumunuzdan aldığınız arşiv) dosyasını indirip açın. Ortaya çıkan `AraziKullanimDB.gpkg` dosyasını güvenilir ve kısa yol içermeyen bir klasöre taşıyın; önerilen dizin yapısı `D:\PLN3113\Veri` veya `C:\PLN3113\Veri` şeklindedir.
+2. **QGIS'te kaynağı bağla:** QGIS 3.22+ sürümünü açın. **Tarayıcı Paneli**'nden **GeoPackage** başlığına sağ tıklayıp **Bağlantı Ekle** seçeneğini kullanarak `AraziKullanimDB.gpkg` dosyasını gösterin. Bağlantı eklendikten sonra GeoPackage altındaki yeşil simgeli proje dosyasını (QGZ) çift tıklayın; böylece çizgi ve alan formları hazır şekilde QGIS ana görünümünde açılır.
+3. **Çalışma adalarını içe aktar:** Bergama'daki çalışma adalarınızı mevcut projeye referans olarak ekleyin. Geçici katman (ör. "Scratch Layer" veya harici shapefile) olarak eklediğiniz ada geometrilerini seçip **ALAN** katmanına kopyala-yapıştır yapın. Bu işlemden sonra ALAN katmanında yeni kayıtlar oluşturulur.
+4. **Anket verilerini doldur:** ALAN katmanındaki kayıtlar için yapı yılı, hâkim yapı türü, alternatif fonksiyon gibi form alanlarını doldurun. Tüm değer listeleri QField formu ile eşlenmiştir; veri sözlüğündeki kodlara sadık kalın.
+5. **Çizgisel veriyi tamamla:** Aynı süreçle `CIZGI` katmanına geçiş yapın. Yol fonksiyonu, genişlik değerleri, kaldırım/refüj ölçüleri, yol durumu ve yol malzemesi alanlarını formdaki değer haritalarını kullanarak doldurun.
+6. **Geometri geçerliliğini doğrula:** Hem ALAN hem CIZGI katmanında form görünümünde `fid` alanı koşullu biçimlendirme ile renklendirilir: yeşil = geçerli, kırmızı = geçersiz. Veri girişini sonlandırmadan önce `Vector > Geometry Tools > Check Validity` aracını çalıştırarak olası hataları giderin.
+
+> **İpucu:** Proje dosyasını açtığınızda katman grupları, etiket ayarları ve form düzenleri otomatik olarak yüklenir. Böylece QGIS arayüzünde ek bir kurulum gerektirmez.
+
+## Tavsiye Edilen Proje Yapısı
+
+```
+QgislandUseSurveyDB/
+├── data/
+│   └── AraziKullanimDB.gpkg
+├── docs/
+│   └── data_dictionary.md
+├── qgis/
+│   └── Bergama_Arastirma.qgz (opsiyonel proje dosyası)
+└── README.md
+```
+
+> **Not:** GeoPackage dosyası büyük boyutlu olduğundan sürüm kontrolüne dahil edilmez. Dosyayı depoya eklemek yerine `data/` klasöründe yerel olarak tutmanız önerilir.
+
+## QField / Input ile Saha Çalışması
+
+1. QGIS projesini hazırladıktan sonra **QFieldSync** eklentisini yükleyin.
+2. Projeyi hedef klasöre senkronize edin ve `Input`/`QField` uygulamasında açın.
+3. `AlanCalismaSiniri` katmanını "yalnızca oku" moduna alın, diğer katmanlara düzenleme yetkisi verin.
+4. Saha sırasında anket formunu doldurmak için **AlanGruplari** katmanındaki form bileşenlerini kullanın.
+5. Çalışma tamamlandıktan sonra cihazı QGIS'e bağlayın ve değişiklikleri birleştirin.
+6. Saha dönüşünde, yukarıdaki geometri ve form kontrollerini tekrar çalıştırarak veri bütünlüğünü doğrulayın.
+
+## Veri Kalite Kontrolleri
+
+* **Geometri doğrulama:** QGIS'te `Vector > Geometry Tools > Check Validity` aracıyla geçersiz geometrileri kontrol edin. `CIZGI` katmanında `fid` alanı form görünümünde `is_valid($geometry)` ifadesiyle renklendirilir; geçersiz geometriler kırmızı, geçerli geometriler yeşil olarak vurgulanır.
+* **Alan değerleri:** `AraziTuru`, `PlanKarari` gibi alanlar için kod listelerini kullanın. Kod listeleri `docs/data_dictionary.md` dosyasında yer alır.
+* **Alan çatışmaları:** Ada poligonları ile bina sınırlarının çakışmasını kontrol etmek için `Select by Location` fonksiyonundan yararlanın.
+
+## Katkıda Bulunma
+
+1. Bu depoyu forklayın ve yerel ortamınıza klonlayın.
+2. Yeni bir dal oluşturun: `git checkout -b ozellik/ogrenci-formu`.
+3. Yaptığınız değişiklikleri test edin ve `docs/data_dictionary.md` dosyasındaki yönergeleri güncel tutun.
+4. Pull request açarak değişikliklerin gözden geçirilmesini talep edin.
+
+## Lisans
+
+Bu proje [MIT Lisansı](LICENSE) kapsamında lisanslanmıştır.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,10 @@
+# GeoPackage ve diğer büyük veri dosyalarını sürüm kontrolü dışında tut
+*.gpkg
+*.gpkg-shm
+*.gpkg-wal
+*.sqlite
+*.tif
+*.zip
+
+# Saha çalışmalarında oluşan medya dosyaları
+media/

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -1,0 +1,249 @@
+# Arazi Kullanım GeoPackage Veri Sözlüğü
+
+Bu doküman, `AraziKullanimDB.gpkg` GeoPackage dosyasında bulunan ana katmanları, öznitelik alanlarını ve alanların amaçlanan kullanımını özetler. Dosya, Bergama çalışma alanında yapılan arazi kullanım envanterinin dijital kaydıdır ve hem ofis hem de saha ekiplerinin ortak bir veri modeli üzerinden çalışmasını sağlar.
+
+## GeoPackage Dosyası
+
+| Özellik | Değer |
+| --- | --- |
+| Dosya adı | `AraziKullanimDB.gpkg` |
+| Koordinat Referans Sistemi | EPSG:5253 (ITRF96 / TM30 3 Derece) |
+| Çalışma Ölçeği | 1/5000 (ada çizimleri 1/1000 detayında yapılmıştır) |
+| Temel Kullanım | QGIS masaüstü ve QField/Input saha uygulamaları |
+
+## Katmanlar
+
+### 1. `CIZGI`
+
+`CIZGI` katmanı, Bergama çalışmasında toplanan tüm çizgisel altyapı ve ulaşım unsurlarını içerir. Katman QField formu ile tam uyumlu olup aşağıdaki öznitelik alanlarını barındırır:
+
+| Alan | Tip | Uzunluk / Hassasiyet | Açıklama |
+| --- | --- | --- | --- |
+| `fid` | Integer64 | — | Otomatik oluşturulan benzersiz kimlik. Form görünümünde `is_valid($geometry)` ifadesi ile renklendirilir; geçerli geometriler yeşil, hatalı geometriler kırmızı görünür. |
+| `nipfonksiyon` | String | 100 | Çizgi fonksiyonu. Değerler ["Çizgi Fonksiyonu" kod listesi](#cizgi-nipfonksiyon-degerleri) üzerinden seçilir. |
+| `yolTipi` | String | 50 | Kurumsal yol sınıfı veya taşıt yolu türü. |
+| `yolGenislik` | Real | p=10, s=2 | Alan ölçümüne göre girilen birincil yol genişliği (m). |
+| `solKaldirimGenislik` | Real | p=10, s=2 | Sol kaldırım genişliği (m). |
+| `refujGenislik` | Real | p=10, s=2 | Orta refüj genişliği (m). |
+| `SolSeritSayisi` | Integer64 | — | Sol şerit adedi. |
+| `SagSeritSayisi` | Integer64 | — | Sağ şerit adedi. |
+| `yolGenislik2` | Real | p=10, s=2 | Yol kesitine göre hesaplanan ikinci genişlik (m). |
+| `Kullanıcı` | String | 50 | Kaydı oluşturan kullanıcı adı. |
+| `TarihIlk` | DateTime | — | Oluşturma tarihi (QField tarih-saat bileşeni). |
+| `TarihSon` | String | 50 | Güncelleme tarihini tutan metin alanı (örn. QField otomasyon ifadeleriyle güncellenir). |
+| `Uzunluk(m)` | Real | p=10, s=2 | Geometrinin metrik uzunluğu. |
+| `sagKaldirimGenislik` | Real | p=10, s=2 | Sağ kaldırım genişliği (m). |
+| `YolDurum` | String | 20 | Yolun mevcut fiziksel durumu. [Değer haritası](#cizgi-yoldurum-degerleri) kullanılarak seçilir. |
+| `YolMalzeme` | String | 20 | Kaplama malzemesi türü. [Değer haritası](#cizgi-yolmalzeme-degerleri) kullanılarak seçilir. |
+
+#### `CIZGI.nipfonksiyon` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `DEMİRYOLU` | Demiryolu |
+| `BORU HATTI` | Boru Hattı |
+| `ENERJİ NAKİL HATTI` | Enerji Nakil Hattı |
+| `İÇME SUYU ANA HATTI` | İçme Suyu Ana Hattı |
+| `SOĞUTMA SUYU ALMA HATTI` | Soğutma Suyu Alma Hattı |
+| `MANİA PLANI` | Mania Planı |
+| `ERİŞME KONTROLLÜ KARAYOLU (OTOYOL)` | Erişme Kontrollü Karayolu (Otoyol) |
+| `BİRİNCİ DERECE YOL` | Birinci Derece Yol |
+| `İKİNCİ DERECE YOL` | İkinci Derece Yol |
+
+#### `CIZGI.YolDurum` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `IYI` | İyi |
+| `ORTA` | Orta |
+| `KOTU` | Kötü |
+| *(boş)* | Belirtilmemiş |
+
+#### `CIZGI.YolMalzeme` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `BITUMLU_KARISIMLAR` | Asfalt |
+| `BETONARME_KAPLAMA` | Beton |
+| `DOGAL_TAS` | Arnavut |
+| `KILITLI_PARKE` | Parke Taşı |
+| `GRANULER` | Stabilize Toprak |
+
+### 2. `ALAN`
+
+`ALAN` katmanı; fonksiyon, hakim yapı özellikleri ve hizmet alanı stokunu gösteren poligonları içerir. Çalışma ölçeği 1/5000 olup ada sınırları 1/1000 detayında çizilmiştir. Form görünümünde `is_valid($geometry)` koşullu biçimlendirmesi ile geçersiz geometriler kırmızı vurgulanır.
+
+| Alan | Tip | Uzunluk / Hassasiyet | Açıklama |
+| --- | --- | --- | --- |
+| `fid` | Integer64 | — | Otomatik kimlik; geçersiz geometrileri ayırt etmek için `is_valid($geometry)` ifadesiyle renklenir. |
+| `nipfonksiyon` | String | 100 | 1/5000 ölçeğindeki NİP fonksiyon kodu. Değerler ilişkili referans tablosundan seçilir. |
+| `TarihIlk` | DateTime | — | Poligonun oluşturulduğu tarih-saat. |
+| `TarihSon` | DateTime | — | Son güncelleme tarih-saat bilgisi. |
+| `Kullanici` | String | 50 | Kaydı düzenleyen kullanıcı. |
+| `AlanHa` | Real | p=10, s=4 | Nesnenin hektar cinsinden alanı. |
+| `HakimKatSayisi` | Integer64 | — | Ada bazlı ortalama kat sayısı (üst sınır 15). |
+| `HakimYapiTuru` | String | 50 | Hakim yapı türü (aşağıdaki değer listesine bakın). |
+| `YapiYili` | String | 50 | Hakim yapıların yapım dönemi (aşağıdaki değer listesine bakın). |
+| `AnaKonutVarMi?` | String | 50 | Alanda ana konut fonksiyonunun bulunup bulunmadığı (Evet/Hayır). |
+| `OtoparkVarMi?` | String | 50 | Kapalı/açık otopark varlığı (Evet/Hayır). |
+| `OtoparkKamuMu?` | String | 50 | Otopark kamuya mı ait bilgisini tutar. |
+| `OtoparkKapasite?` | String | 50 | Otopark kapasitesi veya açıklaması. |
+| `YatiliLiseVarMi?` | String | 50 | Yatılı lise varlığı için Evet/Hayır alanı. |
+| `EndMeslekLiseVarMi?` | String | 50 | Endüstri/meslek lisesi varlığı. |
+| `OzEgitimOkuluVarMi?` | String | 50 | Özel eğitim okulu varlığı. |
+| `YurtVarMi?` | String | 50 | Öğrenci yurdu varlığı. |
+| `SaglikOcagiVarMi?` | String | 50 | Sağlık ocağı veya aile sağlığı merkezi varlığı. |
+| `HemsireVarMi?` | String | 50 | Sağlık personeli varlığı (Evet/Hayır). |
+| `HakimYapiKalitesi` | String | 50 | Yapı kalitesi sınıfı (aşağıdaki değer listesine bakın). |
+| `KullanimDurumu` | String | 50 | Mevcut kullanım durumu (aşağıdaki değer listesine bakın). |
+| `AlternatifFonksiyon` | String | 50 | Alternatif fonksiyon sınıfı (aşağıdaki değer listesine bakın). |
+
+#### `ALAN.HakimYapiTuru` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `ÇELİK KARKAS` | Çelik Karkas |
+| `BETONARME KARKAS` | Betonarme Karkas |
+| `YIĞMA KAGİR` | Yığma Kagir |
+| `AHŞAP` | Ahşap |
+| `TAŞ` | Taş |
+| `KERPİÇ` | Kerpiç |
+| `GECEKONDU` | Gecekondu |
+
+#### `ALAN.YapiYili` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `1985-1994` | 1985-1994 |
+| `1995-2004` | 1995-2004 |
+| `2005-2014` | 2005-2014 |
+| `2015-2024` | 2015-2024 |
+
+#### `ALAN.HakimYapiKalitesi` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `ÇOK İYİ` | Çok İyi |
+| `İYİ` | İyi |
+| `ORTA` | Orta |
+| `KÖTÜ` | Kötü |
+| `ÇOK KÖTÜ` | Çok Kötü |
+
+#### `ALAN.KullanimDurumu` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `Metruk` | Metruk |
+| `Insaat` | İnşaat Halinde |
+| `Bos Alan` | Boş Alan |
+| `Harabe` | Harabe |
+| `Kullanimda` | Kullanımda |
+
+#### `ALAN.AlternatifFonksiyon` değerleri
+
+| Kod | Etiket |
+| --- | --- |
+| `ARITMA_TESISI` | Atıksu Arıtma Tesisi |
+| `ATIKSU_POMPA_ISTASYONU` | Atıksu Pompa İstasyonu |
+| `BANKA` | Banka |
+| `BELEDIYE_HIZMET_ALANI` | Belediye Hizmet Alanı |
+| `BHA` | BHA |
+| `BOS` | Boş Alan |
+| `BOTANIK_CICEKCILIK` | Botanik - Çiçekçilik |
+| `BOTANIK_CICEKCILIK_SERA` | Botanik - Çiçekçilik + Sera |
+| `BOTANIK_FIDANCILIK` | Botanik - Fidancılık |
+| `BOTANIK_FIDANCILIK_CICEKCILIK` | Botanik - Fidancılık + Çiçekçilik |
+| `BOTANIK_FIDANCILIK_SERA` | Botanik - Fidancılık + Sera |
+| `BOTANIK_SERA` | Botanik - Sera |
+| `CAMASIRHANE` | Çamaşırhane |
+| `COK_FONKSIYONLU_TICARET_HIZMET` | Çok Fonksiyonlu Ticaret-Hizmet |
+| `DEPOLAMA` | Depolama |
+| `DEPO_KONUT` | Depo + Konut |
+| `DEPO_LOJISTIK` | Depolama + Lojistik |
+| `DEPO_TARIM` | Depo + Tarım |
+| `DINI_TESIS` | Dînî Tesis |
+| `EGITIM_KAMPUS` | Eğitim Kampüsü |
+| `EKILI_TARIM` | Ekili Tarım |
+| `EMNIYET_TESISI` | Emniyet Tesisi |
+| `ENERJI_ISTASYONU_AKARYAKIT` | Akaryakıt İstasyonu |
+| `ENERJI_URETIM_TESISI` | Enerji Üretim Tesisi |
+| `HABERLESME_ALTYAPI` | Haberleşme Altyapısı |
+| `HARABE` | Harabe |
+| `HAYVANCILIK` | Hayvancılık |
+| `HAYVAN_BARINAGI` | Hayvan Barınağı |
+| `ICMESUYU_TESISI` | İçmesuyu Tesisi |
+| `ILKOKUL` | İlkokul |
+| `INSAAT` | İnşaat |
+| `ITFAIYE_TESISI` | İtfaiye Tesisi |
+| `IZSU_TESISI` | İZSU Tesisi |
+| `KAMU_HIZMET_ALANI` | Kamu Hizmet Alanı |
+| `KARAYOLU_ALANI` | Karayolu Alanı |
+| `KATI_ATIK_BERTARAF` | Katı Atık Bertaraf Tesisi |
+| `KATI_ATIK_DONUSUM` | Katı Atık Dönüşüm |
+| `KENTSEL_SERVIS_ALANI` | Kentsel Servis Alanı |
+| `KONUT` | Konut |
+| `KONUT_TARIM` | Konut + Tarım |
+| `KONUT_TICARET` | Konut + Ticaret |
+| `KONUT_TICARET_SOSYO_K` | Konut + Ticaret + Sosyo-Kültürel |
+| `KONUT_TICARET_TURIZM` | Konut + Ticaret + Turizm |
+| `KONUT_TURIZM` | Konut + Turizm |
+| `KSS` | Küçük Sanayi Sitesi (KSS) |
+| `LISE` | Lise |
+| `LOJISTIK` | Lojistik |
+| `MESIRE_ALANI` | Mesire Alanı |
+| `MEYVE_TARIMI` | Meyve Tarımı |
+| `MEZARLIK` | Mezarlık |
+| `MUSTEMILAT` | Müstemilat |
+| `OFIS_BURO` | Ofis/Büro |
+| `ORTAOKUL` | Ortaokul |
+| `OSB` | Organize Sanayi Bölgesi (OSB) |
+| `OTOGAR` | Otogar |
+| `OTOPARK` | Otopark |
+| `OTOPARK_TICARET` | Otopark + Ticaret |
+| `PARK` | Park |
+| `PAZAR_YERI` | Pazar Yeri |
+| `PTT` | PTT |
+| `RAYLI_SISTEM` | Raylı Sistem Hattı |
+| `RAYLI_SISTEM_ISTASYONU` | Raylı Sistem İstasyonu |
+| `REKREASYON` | Rekreasyon Alanı |
+| `RESMI_TESIS` | Resmî Tesis |
+| `SAGLIK` | Sağlık |
+| `SAGLIK_KAMPUS` | Sağlık Kampüsü |
+| `SAGLIK_KONUT` | Sağlık + Konut |
+| `SANAYI` | Sanayi |
+| `SANAYI_DEPOLAMA` | Sanayi + Depolama |
+| `SOSYO_KULTUREL_TESIS` | Sosyo-Kültürel Tesis |
+| `SPOR_TESISI` | Spor Tesisi |
+| `TARIM_TICARET` | Tarım + Ticaret |
+| `TEKNIK_ALTYAPI` | Teknik Altyapı Alanı |
+| `TERMINAL` | Terminal |
+| `TICARET` | Ticaret |
+| `TICARET_DEPO` | Ticaret + Depo |
+| `TICARET_SOSYO_K` | Ticaret + Sosyo-Kültürel |
+| `TRAFO` | Trafo |
+| `TURIZM` | Turizm |
+| `TURIZM_TESISI` | Turizm Tesisi |
+| `TURIZM_TICARET` | Turizm + Ticaret |
+| `ZEYTINLIK` | Zeytinlik |
+| `ASKERI_ALAN` | Askeri Alan |
+
+### 3. Diğer katmanlar
+
+GeoPackage içerisinde `CIZGI` ve `ALAN` katmanlarına ek olarak binalar, alan grupları, çalışma sınırı ve ada poligonları gibi tamamlayıcı katmanlar bulunur. Bu katmanların öznitelik şemaları saha çalışması sırasında toplanan verilere göre yapılandırılmıştır ve yeni sürümlerde ayrıntılı tablolar eklenecektir.
+
+## Kod Listeleri
+
+Katmanlardaki tüm kod listeleri QField form yapılandırması ile birlikte gelir; değer haritaları QGIS'te form görüntüsünde otomatik sunulur.
+
+## Veri Yönetimi İpuçları
+
+* `fid` alanı otomatik artan kimlik alanıdır; değerini manuel değiştirmeyin.
+* Saha sırasında QField otomasyonları `TarihIlk` ve `TarihSon` alanlarını güncel tutar. Gerektiğinde QGIS ifade editöründe `now()` veya `format_date()` tabanlı ifadeleri kullanabilirsiniz.
+* Genişlik ve şerit sayısı alanları için metre cinsinden değer girildiğinden emin olun; QGIS'te birim doğrulaması için alan kısıtları eklenebilir.
+
+## Sürüm Kontrolü Tavsiyeleri
+
+* GeoPackage dosyasını Git LFS veya harici bir bulut depolama alanında saklayın.
+* `data/` klasöründe `.gitignore` dosyası oluşturarak büyük boyutlu verilerin yanlışlıkla sürüm kontrolüne eklenmesini engelleyin.
+* Form yapılandırmalarında yapılan değişiklikleri belgelemeniz için bu doküman üzerinde ilgili bölümü güncelleyin.
+


### PR DESCRIPTION
## Summary
- expand the README with a detailed workflow for extracting the GeoPackage and adding it to QGIS via the Browser panel
- describe how students should transfer their island geometries into the ALAN layer before filling out forms
- highlight the geometry validation cues and data-entry order for both ALAN and CIZGI layers

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68db00f61eac832da81daa9e6f62e3ac